### PR TITLE
CURLOPT_SSL_VERIFYHOST should be set to a value of 2

### DIFF
--- a/libraries/mailchimp.php
+++ b/libraries/mailchimp.php
@@ -29,7 +29,7 @@ class Mailchimp
 		curl_setopt($ch, CURLOPT_URL, $endpoint);
 		curl_setopt($ch, CURLOPT_TIMEOUT, 30);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, true);
+		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
 		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
 		curl_setopt($ch, CURLOPT_POST, true);
 		curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);


### PR DESCRIPTION
CURLOPT_SSL_VERIFYHOST should be set to a value of 2 in production environments.

See: http://php.net/manual/en/function.curl-setopt.php
