### PR TITLE
Updated camelcase function to work in PHP 5.5

### DIFF
--- a/src/Travis/Mailchimp.php
+++ b/src/Travis/Mailchimp.php
@@ -66,7 +66,12 @@ class Mailchimp {
      */
     protected static function camelcase($str)
     {
-        return lcfirst(preg_replace('/(^|_)(.)/e', "strtoupper('\\2')", strval($str)));
-    }
+        return lcfirst(
+            preg_replace_callback('/(^|_)(.)/', function($matches)
+            {
+                return strtoupper($matches[2]);
+            }, strval($str))
+        );
+   }
 
 }


### PR DESCRIPTION
Hey man,

I just noticed that this lib was throwing an exception in PHP5.5 and needs to use preg_replace_callback instead of preg_replace. I tested my update to the code and it seems to work without any issues.

Cheers,
Alex
